### PR TITLE
fix: remove redundant updateTransform in SpineSystem

### DIFF
--- a/packages/spine-base/lib/SpineSystem.ts
+++ b/packages/spine-base/lib/SpineSystem.ts
@@ -66,7 +66,6 @@ export default class SpineSystem extends Renderer {
       // TODO: 类型
       // @ts-ignore
       this.armatures[key].update(e.deltaTime * 0.001)
-      this.armatures[key].updateTransform()
     }
     super.update()
   }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [ ] The commit message follows our [guidelines](https://github.com/eva-engine/eva.js/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Bug fix

### What is the current behavior? (You can also link to an open issue here)
Spine's updateTransform will be called twice in one frame.

### What is the new behavior (if this is a feature change)?
Spine's updateTransform will only be called in container's children update.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No

### Other information: